### PR TITLE
Edit the "Serviços Acadêmicos" screen

### DIFF
--- a/src/app/core/servicos-academicos/servicos-academicos.component.html
+++ b/src/app/core/servicos-academicos/servicos-academicos.component.html
@@ -54,11 +54,11 @@
         programa e clique em "buscar".
       </li>
       <li>
-        Neste 1º semestre o próprio sistema irá montar a sua grade horária. Você não
-        precisa se preocupar em se matricular em disciplinas.
+        Neste 1º semestre, o próprio sistema irá montar a sua grade horária, então
+        você não precisa se preocupar em se matricular em disciplinas.
       </li>
       <li>
-        Clicando em uma das disciplinas na grade, irá abrir um painel com duas abas:
+        Clicando em uma das disciplinas na grade, irá abrir um painel, abaixo, com duas abas:
         "disciplina" e "oferecimento".
       </li>
       <li>
@@ -93,12 +93,12 @@
     <ul>
       <li>Histórico escolar: Graduação (no painel à esquerda) → Histórico Escolar</li>
       <li>
-        Atestado de aluno, de matrícula, etc: Graduação → Emissão de documentos →
+        Atestado de aluno, de matrícula, etc: Graduação → Emissão de Documentos →
         Documentos
       </li>
       <li>
         Evolução no curso (veja seu andamento nas matérias obrigatórias do curso):
-        Graduação → Acompanhamentos → Evolução no curso.
+        Graduação → Acompanhamentos → Evolução no Curso.
       </li>
     </ul>
   </section>
@@ -108,16 +108,16 @@
     <ul>
       <li>Faça login → Restaurante Universitário</li>
       <li>
-        Em "Seu extrato" você encontra o valor disponível na sua conta do restaurante
-        universitário.
+        Em "Meu Extrato" você encontra o valor disponível na sua conta do restaurante
+        universitário, além de todas as movimentações já realizadas.
       </li>
       <li>
-        Em "Boleto" você encontra um histórico dos boletos gerados, e também pode gerar um
-        novo em "Comprar" para depositar um valor na sua conta.
+        Em "Boleto" você encontra um histórico dos boletos gerados, porém não é mais possível
+        gerar um novo, já que, agora, todas as recargas são realizadas via Pix.
       </li>
       <li>
-        Em "Pix" você encontra um histórico dos pix pagos, e também pode gerar uma chave
-        para realizar um novo pagamento pix em "Comprar" para depositar um valor na sua
+        Em "Pix" você encontra um histórico dos Pix pagos, e também pode gerar uma chave
+        para realizar um novo pagamento Pix em "Comprar" assim depositando um valor na sua
         conta.
       </li>
     </ul>
@@ -132,13 +132,13 @@
       </li>
       <li>
         Você pode ver todos os editais passados e os em andamento em: Relações
-        Internacionais → Acesso Público → Editais → Alunos de graduação → Editais
+        Internacionais → Editais → Alunos de Graduação → Editais
       </li>
       <li>
         A classificação em cada edital geralmente é de acordo com sua média normalizada
         por turma, ela começa a ser calculada após 2 semestres concluídos, que você pode
-        encontrar em: Relações Internacionais → Acesso Público → Editais → Alunos de
-        graduação → Média Normalizada por Turma
+        encontrar em: Relações Internacionais → Editais → Alunos de
+        Graduação → Média Normalizada por Turma GRADUAÇÃO
       </li>
       <li>
         A universidade também oferece editais de bolsa para te auxiliar com os custos. A
@@ -198,7 +198,7 @@
   </p>
   <ul>
     <li>
-      Google Drive com <strong>100 GB de armazenamento</strong> e Drives compartilhados;
+      Google Drive com <strong>15 GB de armazenamento</strong>;
     </li>
     <li>Reuniões no Google Meet, com opção de as gravar;</li>
     <li>
@@ -270,7 +270,7 @@
   </p>
   <p>
     Para cursar disciplinas de outros cursos, você terá que fazer um requerimento pelo
-    JupterWeb: Faça login &#8594; Graduação (no painel à direita) &#8594; Requerimento
+    JupiterWeb: Faça login &#8594; Graduação (no painel à direita) &#8594; Requerimento
     &#8594; Requerimento de matrícula. O período para enviar requerimentos ocorre depois
     das duas interações de matrícula. Para conferir a data, é só olhar no calendário
     acadêmico.

--- a/src/app/core/servicos-academicos/servicos-academicos.component.html
+++ b/src/app/core/servicos-academicos/servicos-academicos.component.html
@@ -54,12 +54,12 @@
         programa e clique em "buscar".
       </li>
       <li>
-        Neste 1º semestre, o próprio sistema irá montar a sua grade horária, então
-        você não precisa se preocupar em se matricular em disciplinas.
+        Neste 1º semestre, o próprio sistema irá montar a sua grade horária, então você
+        não precisa se preocupar em se matricular em disciplinas.
       </li>
       <li>
-        Clicando em uma das disciplinas na grade, irá abrir um painel, abaixo, com duas abas:
-        "disciplina" e "oferecimento".
+        Clicando em uma das disciplinas na grade, irá abrir um painel, abaixo, com duas
+        abas: "disciplina" e "oferecimento".
       </li>
       <li>
         Em <strong>"disciplina"</strong> estão informações sobre a ementa da disciplina:
@@ -112,8 +112,8 @@
         universitário, além de todas as movimentações já realizadas.
       </li>
       <li>
-        Em "Boleto" você encontra um histórico dos boletos gerados, porém não é mais possível
-        gerar um novo, já que, agora, todas as recargas são realizadas via Pix.
+        Em "Boleto" você encontra um histórico dos boletos gerados, porém não é mais
+        possível gerar um novo, já que, agora, todas as recargas são realizadas via Pix.
       </li>
       <li>
         Em "Pix" você encontra um histórico dos Pix pagos, e também pode gerar uma chave
@@ -137,8 +137,8 @@
       <li>
         A classificação em cada edital geralmente é de acordo com sua média normalizada
         por turma, ela começa a ser calculada após 2 semestres concluídos, que você pode
-        encontrar em: Relações Internacionais → Editais → Alunos de
-        Graduação → Média Normalizada por Turma GRADUAÇÃO
+        encontrar em: Relações Internacionais → Editais → Alunos de Graduação → Média
+        Normalizada por Turma GRADUAÇÃO
       </li>
       <li>
         A universidade também oferece editais de bolsa para te auxiliar com os custos. A
@@ -197,9 +197,7 @@
     Sua conta USP está integrada com as soluções do Google. Com isso você pode aproveitar:
   </p>
   <ul>
-    <li>
-      Google Drive com <strong>15 GB de armazenamento</strong>;
-    </li>
+    <li>Google Drive com <strong>15 GB de armazenamento</strong>;</li>
     <li>Reuniões no Google Meet, com opção de as gravar;</li>
     <li>
       Google Calendar para organizar suas reuniões e marcar encontros no Google Meet.

--- a/src/app/core/servicos-academicos/servicos-academicos.component.ts
+++ b/src/app/core/servicos-academicos/servicos-academicos.component.ts
@@ -27,22 +27,6 @@ export class ServicosAcademicosComponent {
     },
     {
       image: {
-        src: '/assets/images/servicos-academicos/canva.svg',
-        alt: 'Logo da Canva Pro',
-        caption: 'Canva Pro',
-      },
-      modal: {
-        image: {
-          src: '/assets/images/servicos-academicos/canva.svg',
-          alt: 'Logo da Canva Pro',
-        },
-        text: 'Aqueles que adquirem o pacote de desenvolvedor de aluno do GitHub também podem obter um ano de acesso gratuito ao Canva Pro. Para isso basta entrar no link abaixo, fazer o login e vincular com sua conta do GitHub.',
-        title: 'Canva Pro',
-        url: 'http://bit.ly/CanvaProEducation',
-      },
-    },
-    {
-      image: {
         src: '/assets/images/servicos-academicos/coursera.svg',
         alt: 'Logo da Coursera',
         caption: 'Coursera',
@@ -68,9 +52,9 @@ export class ServicosAcademicosComponent {
           src: '/assets/images/servicos-academicos/dell.svg',
           alt: 'Logo da Dell',
         },
-        text: 'Existem descontos voltados a estudantes para compras de eletrônicos na loja da Dell.Visite a página para saber valores e o passo a passo de como conseguir os descontos.',
+        text: 'Existem descontos voltados a estudantes para compras de eletrônicos na loja da Dell. Visite a página para saber valores e o passo a passo de como conseguir os descontos.',
         title: 'Dell',
-        url: 'http://bit.ly/DescontosDell',
+        url: 'https://www.dell.com/pt-br/lp/students',
       },
     },
     {
@@ -116,7 +100,7 @@ export class ServicosAcademicosComponent {
           src: '/assets/images/servicos-academicos/gsuite.svg',
           alt: 'Logo do GSuite',
         },
-        text: 'Estando logado no e-mail institucional você tem acesso ao Drive com 100 GB de armazenamento, ferramentas administrativas adicionais e configurações avançadas do Workspace da Google.',
+        text: 'Estando logado no e-mail institucional você tem acesso ao Drive com 15 GB de armazenamento, ferramentas administrativas adicionais e configurações avançadas do Workspace da Google.',
         title: 'GSuite',
         url: 'https://www.sti.usp.br/cooperacao/google-g-suite-education/',
       },
@@ -148,7 +132,7 @@ export class ServicosAcademicosComponent {
           src: '/assets/images/servicos-academicos/mubi.svg',
           alt: 'Logo do Mubi',
         },
-        text: 'Alunos USP têm acesso a plataforma MUBI com desconto na mensalidade para estudantes, de R$29,90 por mês para R$18,90 por mês.',
+        text: 'Alunos USP têm acesso a plataforma MUBI com desconto na mensalidade para estudantes, de R$34,90 por mês para R$21,90 por mês.',
         title: 'Mubi',
         url: 'https://mubi.com/pt/student',
       },
@@ -166,7 +150,7 @@ export class ServicosAcademicosComponent {
         },
         text: 'Aplicativo de organização com grande variedade de ferramentas. Ao se cadastrar com o e-mail USP, você recebe o plano “Personal”. Para ativar o plano “Personal Pro”, basta entrar na sua conta, clicar em “Settings & Members” > “Updates” > “Get free education plan” e criar sua senha.',
         title: 'Notion',
-        url: 'https://www.notion.so/',
+        url: 'https://www.notion.com/product/notion-for-education',
       },
     },
     {
@@ -214,7 +198,7 @@ export class ServicosAcademicosComponent {
         },
         text: 'Estudantes têm direito a 50% de desconto por um período de 12 meses consecutivos. É possível ativar até três períodos adicionais ao comprovar que ainda está qualificado para receber essa oferta.',
         title: 'Spotify Premium',
-        url: 'https://spotify.com',
+        url: 'https://www.spotify.com/br-pt/premium/#plans',
       },
     },
     {


### PR DESCRIPTION
Fixes #7

## Description

In this task, some information were updated in the Serviços Acadêmicos screen.

## Changes

In order complete the task, I propose the following changes:

 - Update texts and links accordingly to new procedures;
 - Remove CanvaPro from the mimos section, since it's no longer being offered.

## Relevant screenshots
![image](https://github.com/user-attachments/assets/5655e692-d5c1-4e5c-8cc7-63ce838c87ab)
![image](https://github.com/user-attachments/assets/c760d4c0-c446-47e1-a991-ba3b065a2a98)
![image](https://github.com/user-attachments/assets/c9c16373-980e-4841-9047-b723fadc80b6)
![image](https://github.com/user-attachments/assets/87b6eacc-04e6-4581-b03b-edd96ef108d2)
![image](https://github.com/user-attachments/assets/cd25c7c5-c31a-4d3e-a6ef-91fec17f5901)
