### PR TITLE
Edit the "ICs e Extracurriculares" screen

### DIFF
--- a/src/app/core/ic-extra/ic-extra.component.html
+++ b/src/app/core/ic-extra/ic-extra.component.html
@@ -124,3 +124,112 @@
     também existem outros!
   </p>
 </section>
+
+<section>
+  <a id="creditos"></a>
+  <app-title [subtitle]="true">Créditos AAC e AEx</app-title>
+  <p>
+    Você provavelmente já ouviu algum veterano comentando sobre
+    <strong
+      >Créditos <abbr title="Atividades Acadêmicas Complementares">AAC</abbr></strong
+    >
+    e <strong>Créditos <abbr title="Atividades Extensionistas">AEx</abbr></strong
+    >, não é mesmo? E provavelmente você ficou bem perdido sobre o que são cada um destes
+    e como você vai fazer pra consegui-los, né? Mas pode ficar tranquilo, seus problema
+    acabaram, já que vamos explicar direitinho tudo isso!
+  </p>
+
+  <p>
+    Antes de seguir para a explicação, vale a pena lembrar que os grupos
+    extracurriculares, as iniciações científicas, as monitorias, e outras atividades serão
+    seus grandes aliados para obter estes créditos! Cada tipo de crédito tem requisitos
+    específicos a ser cumpridos, porém sempre é possível encontrar atividades que lucram
+    ambos os créditos para o aluno, então, não dê bobeira!
+  </p>
+
+  <h4>Créditos AAC</h4>
+
+  <p>
+    Os Créditos AAC advém da realização de
+    <strong> Atividades Acadêmicas Complementares</strong>. Tais atividades compreendem,
+    por exemplo, ministrar monitoria, participar em empresas júniores, organizar
+    competições esportivas, realizar iniciação científica, participar em semanas
+    acadêmicas, participar na Comissão da Semana de Recepção dos Calouros, entre muitas
+    outras atividades, como pode ser visto nos links abaixo. Observa-se que estas
+    atividades complementam a sua graduação e estão relacionadas, de alguma forma, à área
+    acadêmica, e, por isso, recebem a sigla AAC, sendo muito importantes para a sua
+    formação profissional.
+  </p>
+
+  <p>
+    Todos os alunos ingressantes da USP a partir de 2021, precisam obter créditos AAC para
+    poderem se graduar e a quantidade exata de créditos necessária está presente na grade
+    curricular de cada curso. As atividades que podem ser realizadas e a quantidade de
+    créditos referentes a cada uma delas podem ser encontradas na
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://eesc.usp.br/comunicacao/wp-content/uploads/2020/09/AAC-apendice_Creditos-atividades-E.-Curriculares-Versao-1.3.pdf"
+      >Referência para Registro</a
+    >
+    e na
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://eesc.usp.br/comunicacao-admin/wp-content/uploads/2021/07/Comparativo-tabela-atividades-AAC-aprovada-pela-CG-e-a-do-Jupiterweb_publicado.pdf"
+      >Tabela Comparativa</a
+    >.
+  </p>
+
+  <p>
+    Caso você tenha realizado uma destas atividades, o procedimento para cadastro é muito
+    simples, basta entrar no Júpiterweb e ir em:
+    <strong>
+      Requerimento → Atividades Acadêmicas Complementares - AAC → (Selecionar o Programa)
+      → Incluir → (Preencher as Informações Necessárias) → Encaminhar para Análise </strong
+    >. Porém, se ainda houver dúvida, há uma aba "Tutorial" que você pode acessar no
+    Júpiterweb em:
+    <strong>Requerimento → Atividades Acadêmicas Complementares - AAC → Tutorial</strong>.
+  </p>
+
+  <h4>Créditos AEx</h4>
+
+  <p>
+    Os Créditos AEx advém da realização de
+    <strong>Atividades Extensionistas Curriculares</strong>. Tais atividades estão
+    relacionadas com o processo de levar o conhecimento produzido na univerdade para a
+    comunidade que vive ao redor dela, assim, podendo trazer beneficios para a sociedade
+    por inúmeras formas. Tais atividades devem seguir alguns critérios específicos como:
+    ser coordenada, acompanhada e avaliada por um docente coordenador; ser realizada por
+    estudante(s); ser voltada a grupos sociais definidos, externos à universidade; ser
+    avaliada para e com o grupo social; e, preferencialmente, ser gratuita.
+  </p>
+
+  <p>
+    Em 2023, as avaliações do MEC passaram a considerar a extensão como parte obrigatória
+    do currículo, sendo assim, a USP adotou medidas para viabilizar a curricularização da
+    extensão para os cursos oferecidos pela mesma. No documento
+    <a
+      target="_blank"
+      rel="noopener noreferrer"
+      href="https://www2.ifsc.usp.br/portal-ifsc/wp-content/uploads/2024/03/Guia-curricularizacao-PRCEU-PRG.pdf"
+      >"Regulamentação da Curricularização da Extensão na Universidade de São Paulo:
+      conceituação, operacionalização e implementação"</a
+    >, todos os aspectos relacionados a este processo estão bem descritos, incluindo
+    formulários e fluxogramas para cadastro de novas atividades, um FAQ contendo as
+    principais dúvidas que podem sugir com relação às atividades e créditos
+    extensionistas, entre outros.
+  </p>
+
+  <p>
+    Mas, para que você não tenha que ler todo o documento acima, vamos resumir os
+    principais pontos. Para aqueles que ingressaram após 2023 concluirem o curso, será
+    necessário que 10% da carga horária seja composta de atividades de extensão, no caso
+    da Engenharia Elétrica, 400 horas. Os institutos são responsáveis por alocar estes
+    créditos em disciplinas da graduação, de forma que os estudantes não precisem se
+    envolver em novas atividades para finalizar o curso. Porém, ainda está ocorrendo uma
+    adaptação a tais medidas, então pode ser necessário que você adquira estes créditos
+    ingressando em algum grupo extracurricular ou buscando atividades pelo próprio sistema
+    Júpiterweb no menu "Atividades Extensionistas Curriculares (AEx)".
+  </p>
+</section>

--- a/src/app/core/ic-extra/ic-extra.component.ts
+++ b/src/app/core/ic-extra/ic-extra.component.ts
@@ -25,22 +25,22 @@ export class IcExtraComponent {
     {
       name: 'Atlética CAASO',
       categories: [ExtracurricularGroupTypes.Sports],
-      url: 'http://atleticacaaso.com/',
+      url: 'https://linktr.ee/atleticacaaso',
     },
     {
       name: 'Baja EESC - USP',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'https://www.bajaeescusp.com/',
+      url: 'https://baja.eesc.usp.br/',
     },
     {
       name: 'CAASO',
       categories: [ExtracurricularGroupTypes.Representative],
-      url: 'https://www.facebook.com/CAASO.USP/',
+      url: 'https://linktr.ee/caaso',
     },
     {
       name: 'Campanha USP do Agasalho',
       categories: [ExtracurricularGroupTypes.Social],
-      url: 'https://www.facebook.com/campanhadoagasalhouspsc/',
+      url: 'https://campanhauspdoagasalho.eesc.usp.br/',
     },
     {
       name: 'Centro de Voluntariado Universitário de São Carlos',
@@ -50,7 +50,7 @@ export class IcExtraComponent {
     {
       name: 'Cia de Dança CAASO',
       categories: [ExtracurricularGroupTypes.Artistic],
-      url: 'https://www.facebook.com/CompanhiadeDancaCAASO/',
+      url: 'https://linktr.ee/ciadedancacaaso',
     },
     {
       name: 'Coletivo de Mulheres CAASO/FEDERAL',
@@ -65,12 +65,12 @@ export class IcExtraComponent {
     {
       name: 'ECon Equipe de Concreto',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'https://www.facebook.com/econeescusp/',
+      url: 'https://linktr.ee/econ.usp',
     },
     {
       name: 'EESC - USP Aerodesign',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'http://www3.eesc.usp.br/aerodesign/',
+      url: 'https://aerodesign.eesc.usp.br/',
     },
     {
       name: 'EESC - USP Formula SAE',
@@ -80,7 +80,7 @@ export class IcExtraComponent {
     {
       name: 'EESC - USP Mileage',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'http://www.mileage.eesc.usp.br/',
+      url: 'https://mileage.eesc.usp.br/',
     },
     {
       name: 'EESC - USP Tupã',
@@ -98,7 +98,7 @@ export class IcExtraComponent {
     {
       name: 'Enactus CAASO - USP',
       categories: [ExtracurricularGroupTypes.Social],
-      url: 'https://www.facebook.com/EnactusCSaoCarlos/',
+      url: 'https://www.instagram.com/time_uspsc/',
     },
     {
       name: 'FoCA',
@@ -111,19 +111,24 @@ export class IcExtraComponent {
       url: 'https://www.facebook.com/gaperia/',
     },
     {
-      name: 'GEISA',
+      name: 'GEISA - Grupo de Estudos e Intervenções SocioAmbientais',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'https://www.facebook.com/geisasaocarlos/',
+      url: 'https://www.instagram.com/geisa.usp/',
+    },
+    {
+      name: 'GELOS - Grupo de Extensão em Livre & Open Source',
+      categories: [ExtracurricularGroupTypes.Technical],
+      url: 'https://gelos.club/sobre/',
     },
     {
       name: 'GMA - Grupo de Manutenção de Aeronaves',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'https://www.facebook.com/gmausp/',
+      url: 'https://www.instagram.com/gma_eesc_usp/',
     },
     {
-      name: 'Grupo de Som CAASO',
+      name: 'GSom - Grupo de Som CAASO',
       categories: [ExtracurricularGroupTypes.Artistic],
-      url: 'https://www.facebook.com/gsomcaaso/',
+      url: 'https://www.instagram.com/gsomcaaso/',
     },
     {
       name: 'IEEE Student Branch',
@@ -133,27 +138,27 @@ export class IcExtraComponent {
     {
       name: 'Liga de Empreendedorismo de São Carlos',
       categories: [ExtracurricularGroupTypes.Business],
-      url: 'https://www.facebook.com/ligadeempreendedorismosc/',
+      url: 'https://www.instagram.com/lesc_sanca/',
     },
     {
       name: 'Liga do Mercado Financeiro de São Carlos',
       categories: [ExtracurricularGroupTypes.Business],
-      url: 'https://www.lmf-saocarlos.com/',
+      url: 'https://www.facebook.com/lmf.saocarlos/',
     },
     {
       name: 'NUANCES',
       categories: [ExtracurricularGroupTypes.Representative],
-      url: 'https://www.facebook.com/nuancescaaso/?fref=mentions',
+      url: 'https://linktr.ee/Nuances_CAASO',
     },
     {
       name: 'Operação Natal',
       categories: [ExtracurricularGroupTypes.Social],
-      url: 'https://www.facebook.com/operacaonatalsc/',
+      url: 'https://operacaonatal.faiufscar.com/',
     },
     {
       name: 'Projeto Semente',
       categories: [ExtracurricularGroupTypes.Social],
-      url: 'https://www.facebook.com/semente.usp/',
+      url: 'https://semente.eesc.usp.br/',
     },
     {
       name: 'Projeto Sol',
@@ -163,27 +168,27 @@ export class IcExtraComponent {
     {
       name: 'SA-SEL',
       categories: [ExtracurricularGroupTypes.Representative],
-      url: 'https://www.facebook.com/sasel.usp/',
+      url: 'https://www.instagram.com/sasel.usp/',
     },
     {
       name: 'Sanca Social',
       categories: [ExtracurricularGroupTypes.Social],
-      url: 'https://www.facebook.com/sancasocial/',
+      url: 'http://sancasocial.icmc.usp.br/',
     },
     {
       name: 'Semear',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'http://www.semear.eesc.usp.br/',
+      url: 'https://semear.eesc.usp.br/',
     },
     {
       name: 'Topus - Pesquisas Aeroespaciais',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'http://facebook.com/grupotopus',
+      url: 'https://sites.google.com/view/topusprojetosaeroespaciais/home',
     },
     {
       name: 'Warthog Robotics',
       categories: [ExtracurricularGroupTypes.Technical],
-      url: 'https://www.facebook.com/WarthogRobotics/',
+      url: 'https://wr.sc.usp.br/',
     },
     {
       name: 'Zenith - USP',

--- a/src/app/core/sidebar/sidebar.component.ts
+++ b/src/app/core/sidebar/sidebar.component.ts
@@ -249,6 +249,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
           title: 'Grupos Extracurriculares',
           id: 'extracurriculares',
         },
+        {
+          title: 'Créditos AAC e AEx',
+          id: 'creditos',
+        },
       ],
     },
     {


### PR DESCRIPTION
Fixes #8

## Description

In this task, the links of most of the extracurricular groups social media needed to be updated. Also some new extracurricular groups needed to be added. A new section explaining how AAC and AEx credits work needed to be added to guide the new students about this important themes.

## Changes

In order complete the task, I propose the following changes:

 - Update extracurricular groups links
 - Add "Créditos AAC e AEx" new section
 - Add new extracurricular groups
 - Update some extracurricular groups' names

## Relevant screenshots
![image](https://github.com/user-attachments/assets/dd6a8f3a-0962-4203-9fee-18fcdad1ef6c)
![image](https://github.com/user-attachments/assets/2372b355-e153-4516-acd8-e406310a9036)
![image](https://github.com/user-attachments/assets/85a234fd-a3a2-456d-9315-888b3bfd7e24)
![image](https://github.com/user-attachments/assets/d699c900-d693-4abc-b93d-3247d9fe8c85)
![image](https://github.com/user-attachments/assets/eb9ee4f4-9c7d-4ea9-9b75-2dfdae7435f3)
